### PR TITLE
use new FindPython module to follow CMP0148

### DIFF
--- a/SparseSolvPy/CMakeLists.txt
+++ b/SparseSolvPy/CMakeLists.txt
@@ -4,6 +4,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${Basedir})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${Basedir})
 
 message("Pybind export in SparseSolvPy !") 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+    set(PYBIND11_FINDPYTHON ON)
+endif()
 find_package(pybind11 REQUIRED)
 pybind11_add_module(SparseSolvPy 
   MODULE 


### PR DESCRIPTION
CMake's FindPythonInterp and FindPythonLibs modules had issues with complex Python environments [^17546]. CMake 3.12 introduced the FindPython module as a replacement and deprecated the old modules [^fpy.1819][^fpy.reln]. As of CMake 3.27, policy CMP0148 disables the old modules by default [^148.doc][^148.disc].

Pybind11 3.0+ supports the new FindPython module [^pyb.mod].

This request enables `PYBIND11_FINDPYTHON` to use FindPython instead of the deprecated modules.

---
従来の CMake は FindPythonInterp / FindPythonLibs モジュールを用いて Python 処理系を探索していましたが，複雑な環境における探索に課題がありました[^17546]．
CMake 3.12 から新たに FindPython モジュールが追加され，旧モジュールは非推奨となりました[^fpy.1819][^fpy.reln]．
CMake 3.27 以降は，ポリシー CMP0148 のもとで旧モジュールは使用できなくなります[^148.doc][^148.disc].

Pybind11 も旧モジュール FindPythonInterp / FindPythonLibs を使用していましたが，Pybind11 3.0 から FindPython モジュールをサポートしています[^pyb.mod]．
```
Make Warning (dev) at /opt/homebrew/share/cmake/pybind11/FindPythonLibsNew.cmake:101 (message):
  Policy CMP0148 is not set: The FindPythonInterp and FindPythonLibs modules
  are removed.  Run "cmake --help-policy CMP0148" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning, or
  preferably upgrade to using FindPython, either by calling it explicitly
  before pybind11, or by setting PYBIND11_FINDPYTHON ON before pybind11.
Call Stack (most recent call first):
  /opt/homebrew/share/cmake/pybind11/pybind11Tools.cmake:44 (find_package)
  /opt/homebrew/share/cmake/pybind11/pybind11Common.cmake:226 (include)
  /opt/homebrew/share/cmake/pybind11/pybind11Config.cmake:257 (include)
  SparseSolvPy/CMakeLists.txt:7 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

このリクエストは， `PYBIND11_FINDPYTHON` をオンにして FindPython モジュールを使用するように変更するものです．

[^17546]: https://gitlab.kitware.com/cmake/cmake/-/issues/17546
[^fpy.1819]: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1819
[^fpy.reln]: https://cmake.org/cmake/help/v3.12/release/3.12.html#modules
[^148.doc]: https://cmake.org/cmake/help/v3.27/policy/CMP0148.html
[^148.disc]: https://discourse.cmake.org/t/cmake-3-27-0-rc2-is-ready-for-testing/8315
[^pyb.mod]: https://pybind11.readthedocs.io/en/latest/cmake/index.html#modes